### PR TITLE
Update qpm.json

### DIFF
--- a/qpm.json
+++ b/qpm.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "id": "beatsaber-hook",
-      "versionRange": "^1.2.6",
+      "versionRange": "*",
       "additionalData": {
         "extraFiles": [
           "src/inline-hook"


### PR DESCRIPTION
Realistically config-utils will work with any version of bs-hooks as long as it has rapid-json.